### PR TITLE
결과 CRUD + 승인/거절

### DIFF
--- a/manager/src/main/java/com/rest/api/controller/ResultController.java
+++ b/manager/src/main/java/com/rest/api/controller/ResultController.java
@@ -1,0 +1,8 @@
+package com.rest.api.controller;
+
+import com.rest.api.controller.base.BaseController;
+import com.rest.api.model.dto.request.ResultRequest;
+import com.rest.api.model.dto.response.ResultResponse;
+
+public interface ResultController extends BaseController<ResultRequest, ResultResponse> {
+}

--- a/manager/src/main/java/com/rest/api/controller/impl/ManagerControllerImpl.java
+++ b/manager/src/main/java/com/rest/api/controller/impl/ManagerControllerImpl.java
@@ -4,17 +4,14 @@ import com.rest.api.controller.ManagerController;
 import com.rest.api.controller.base.BaseControllerImpl;
 import com.rest.api.model.Manager;
 import com.rest.api.model.dto.request.ManagerRequest;
-import com.rest.api.model.dto.request.ResultRequest;
 import com.rest.api.model.dto.response.ManagerResponse;
-import com.rest.api.model.dto.response.ResultResponse;
 import com.rest.api.repository.ManagerRepository;
 import com.rest.api.service.ManagerService;
 import com.rest.api.service.base.BaseService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(path = "/manager")
@@ -27,19 +24,5 @@ public class ManagerControllerImpl extends BaseControllerImpl<Manager, ManagerRe
 
     public ManagerControllerImpl(BaseService<Manager, ManagerRequest, ManagerResponse, ManagerRepository> baseService) {
         super(baseService);
-    }
-
-    @PostMapping("/result")
-    public ResponseEntity decideResult(@RequestBody ResultRequest rRs) {
-
-        ResultResponse response = new ResultResponse();
-        if (rRs.getResult()) {
-            modelMapper.map(rRs, ResultResponse.class);
-            response.setIsAccepted("승인되었습니다.");
-        } else {
-            response.setIsAccepted("거절되었습니다.");
-        }
-
-        return new ResponseEntity(response, HttpStatus.OK);
     }
 }

--- a/manager/src/main/java/com/rest/api/controller/impl/ResultControllerImpl.java
+++ b/manager/src/main/java/com/rest/api/controller/impl/ResultControllerImpl.java
@@ -1,0 +1,46 @@
+package com.rest.api.controller.impl;
+
+import com.rest.api.controller.ResultController;
+import com.rest.api.controller.base.BaseControllerImpl;
+import com.rest.api.model.Result;
+import com.rest.api.model.dto.request.AcceptationRequest;
+import com.rest.api.model.dto.request.ResultRequest;
+import com.rest.api.model.dto.response.AcceptationResponse;
+import com.rest.api.model.dto.response.ResultResponse;
+import com.rest.api.repository.ResultRepository;
+import com.rest.api.service.ManagerService;
+import com.rest.api.service.ResultService;
+import com.rest.api.service.base.BaseService;
+import com.rest.api.service.impl.ResultServiceImpl;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.http.HttpResponse;
+
+@RestController
+@RequestMapping(path = "/result")
+public class ResultControllerImpl extends BaseControllerImpl<Result, ResultRequest, ResultResponse, ResultRepository> implements ResultController {
+
+    @Autowired
+    ModelMapper modelMapper;
+    @Autowired
+    ResultServiceImpl resultService;
+
+    public ResultControllerImpl(BaseService<Result, ResultRequest, ResultResponse, ResultRepository> baseService) {
+        super(baseService);
+    }
+
+    /**
+     * 가게 승인/거절 api
+     * id : result id
+     */
+    @PostMapping("/{id}")
+    public ResponseEntity decideAcceptation(@PathVariable Long id, @RequestBody AcceptationRequest result) {
+
+        AcceptationResponse res = resultService.decideAcceptation(id, result);
+        return new ResponseEntity<>(res, HttpStatus.OK);
+    }
+}

--- a/manager/src/main/java/com/rest/api/model/Result.java
+++ b/manager/src/main/java/com/rest/api/model/Result.java
@@ -1,0 +1,59 @@
+package com.rest.api.model;
+
+import com.rest.api.model.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Where(clause = "is_deleted IS false")
+public class Result extends BaseEntity {
+
+    // 승인여부
+    @Column
+    private Boolean result;
+
+    // seller entity 용 로그인, 비밀번호 값
+    @Column
+    private String loginId;
+    @Column
+    private String loginPwd;
+    @Column
+    private String role;
+
+    // store entity 용 값들
+    @Column
+    private String storeName; // 가게이름
+    @Column
+    private String storeImageUrl; // 가게 대표 이미지 url - 이미지 없을 시 기본이미지
+    @Column
+    private String storeAddress; // 가게 주소
+    @Column
+    private String category; // 카테고리
+    @Column
+    private String contact; // 연락처
+    @Column
+    private Double longitude;   // 경도
+    @Column
+    private Double latitude;    // 위도
+    @Column
+    private String openTime; // 운영 시작 시간
+    @Column
+    private String closeTime; // 운영 마감 시간
+    @Column
+    private String saleTimeStart;   // 할인 시작 시간
+    @Column
+    private String saleTimeEnd; // 할인 마감 시간
+    @Column
+    private String saleMatters; // 공지사항
+    @Column
+    private Boolean isOpen; // 가게 운영 여부
+    @Column
+    private String closedDay; // 휴무일 (0-휴무, 1-영업)
+}

--- a/manager/src/main/java/com/rest/api/model/dto/request/AcceptationRequest.java
+++ b/manager/src/main/java/com/rest/api/model/dto/request/AcceptationRequest.java
@@ -1,0 +1,11 @@
+package com.rest.api.model.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class AcceptationRequest {
+
+    // 승인/거절 여부
+    private Boolean result;
+}

--- a/manager/src/main/java/com/rest/api/model/dto/response/AcceptationResponse.java
+++ b/manager/src/main/java/com/rest/api/model/dto/response/AcceptationResponse.java
@@ -1,0 +1,11 @@
+package com.rest.api.model.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class AcceptationResponse {
+
+    private Long resultId;
+    private String result;
+}

--- a/manager/src/main/java/com/rest/api/model/dto/response/ResultResponse.java
+++ b/manager/src/main/java/com/rest/api/model/dto/response/ResultResponse.java
@@ -6,27 +6,30 @@ import lombok.Setter;
 @Getter @Setter
 public class ResultResponse {
 
+    // storeId
+    private Long id;
+
     // 승인여부
-    private String isAccepted;
+    private Boolean result;
 
-    // seller entity 용 로그인, 비밀번호 값
-    private String loginId;
-    private String loginPwd;
-    private String role;
-
-    // store entity 용 값들
+//    // seller entity 용 로그인, 비밀번호 값
+//    private String loginId;
+//    private String loginPwd;
+//    private String role;
+//
+//    // store entity 용 값들
     private String storeName; // 가게이름
-    private String storeImageUrl; // 가게 대표 이미지 url - 이미지 없을 시 기본이미지
-    private String storeAddress; // 가게 주소
+//    private String storeImageUrl; // 가게 대표 이미지 url - 이미지 없을 시 기본이미지
+//    private String storeAddress; // 가게 주소
     private String category; // 카테고리
-    private String contact; // 연락처
-    private Double longitude;   // 경도
-    private Double latitude;    // 위도
-    private String openTime; // 운영 시작 시간
-    private String closeTime; // 운영 마감 시간
-    private String saleTimeStart;   // 할인 시작 시간
-    private String saleTimeEnd; // 할인 마감 시간
-    private String saleMatters; // 공지사항
-    private Boolean isOpen; // 가게 운영 여부
-    private String closedDay; // 휴무일 (0-휴무, 1-영업)
+//    private String contact; // 연락처
+//    private Double longitude;   // 경도
+//    private Double latitude;    // 위도
+//    private String openTime; // 운영 시작 시간
+//    private String closeTime; // 운영 마감 시간
+//    private String saleTimeStart;   // 할인 시작 시간
+//    private String saleTimeEnd; // 할인 마감 시간
+//    private String saleMatters; // 공지사항
+//    private Boolean isOpen; // 가게 운영 여부
+//    private String closedDay; // 휴무일 (0-휴무, 1-영업)
 }

--- a/manager/src/main/java/com/rest/api/repository/ResultRepository.java
+++ b/manager/src/main/java/com/rest/api/repository/ResultRepository.java
@@ -1,0 +1,7 @@
+package com.rest.api.repository;
+
+import com.rest.api.model.Result;
+import com.rest.api.repository.base.BaseRepository;
+
+public interface ResultRepository extends BaseRepository<Result> {
+}

--- a/manager/src/main/java/com/rest/api/service/ResultService.java
+++ b/manager/src/main/java/com/rest/api/service/ResultService.java
@@ -1,7 +1,10 @@
-//package com.rest.api.service;
-//
-//import com.rest.api.service.base.BaseService;
-//import org.apache.catalina.Store;
-//
-//public interface ResultService extends BaseService<> {
-//}
+package com.rest.api.service;
+
+import com.rest.api.model.Result;
+import com.rest.api.model.dto.request.ResultRequest;
+import com.rest.api.model.dto.response.ResultResponse;
+import com.rest.api.repository.ResultRepository;
+import com.rest.api.service.base.BaseService;
+
+public interface ResultService extends BaseService<Result, ResultRequest, ResultResponse, ResultRepository> {
+}

--- a/manager/src/main/java/com/rest/api/service/impl/ResultServiceImpl.java
+++ b/manager/src/main/java/com/rest/api/service/impl/ResultServiceImpl.java
@@ -1,0 +1,56 @@
+package com.rest.api.service.impl;
+
+import com.rest.api.model.Result;
+import com.rest.api.model.dto.request.AcceptationRequest;
+import com.rest.api.model.dto.request.ResultRequest;
+import com.rest.api.model.dto.response.AcceptationResponse;
+import com.rest.api.model.dto.response.ResultResponse;
+import com.rest.api.repository.ResultRepository;
+import com.rest.api.service.ResultService;
+import com.rest.api.service.base.BaseServiceImpl;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ResultServiceImpl extends BaseServiceImpl<Result, ResultRequest, ResultResponse, ResultRepository> implements ResultService {
+
+    @Autowired
+    ModelMapper modelMapper;
+    @Autowired
+    ResultRepository resultRepository;
+    
+    public ResultServiceImpl(ResultRepository repository) {
+        super(repository);
+    }
+
+    /**
+     * 승인/거절 여부 결정하기
+     */
+    public AcceptationResponse decideAcceptation(Long id, AcceptationRequest result) {
+
+        // 신청한 가게 정보 가져오기
+        Result storeRes = resultRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 신청입니다."));
+
+        // 가게 승인/거절 여부 저장
+        storeRes.setResult(result.getResult());
+        resultRepository.save(storeRes);
+
+        // response set
+        AcceptationResponse res = new AcceptationResponse();
+        if (result.getResult()) {
+
+            res.setResultId(id);
+            res.setResult("승인되었습니다.");
+        } else {
+
+            res.setResultId(id);
+            res.setResult("거절되었습니다.");
+        }
+
+        return res;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
- #6 

## 📝 작업사항
### 1. Result 이용한 CRUD 생성
- 승인/거절 여부 확인을 위한 result 엔티티 생성
  - 승인/거절 여부, 로그인 및 비밀번호, 가게 정보 담겨 있음
  - 이 엔티티에 저장을 한 후, 원하는 곳으로 저장 혹은 api 보낼 예정
    - ex. 가게 정보 → Store 엔티티에 저장

### 2. 승인/거절
- Boolean 값만 보내면 Result 엔티티에 저장

### 3. 로직
<img width="258" alt="image" src="https://github.com/Team-JubJub/ZupZup-Web_backend/assets/77785750/db3b0da6-0723-442e-8923-1e081ffe619e">
<br>

- 현재까지 구현된 부분 : 매니저가 가게 승인/거절 가능
- 구현 해야할 부분 : 매니저가 가게 정보 입력하기, Result 값들 Seller, Store에 저장하기, 단건 get 메소드

## 🧐 참고 사항

## 📄 Reference

