### PR TITLE
fix: exception 문서화 + exception handler 작성 + excpetion 수정

### DIFF
--- a/member/src/docs/asciidoc/restdoc.adoc
+++ b/member/src/docs/asciidoc/restdoc.adoc
@@ -8,33 +8,52 @@
 [[Login]]
 == 회원가입
 operation::create-seller[snippets='http-request,request-body,request-fields,response-body,response-fields']
+== 회원가입 실패 (이미 가입한 적 있음)
+operation::fail-create-seller-already-exists[snippets='http-request,request-body,request-fields,response-body']
+== 회원가입 실패 (두 개의 비밀번호가 같지 않음)
+operation::fail-create-seller-not-same-password[snippets='http-request,request-body,request-fields,response-body']
 == Login
 operation::login-success[snippets='http-request,request-body,request-fields,response-body,response-fields']
+== 로그인 실패 (회원을 찾을 수 없음)
+operation::fail-login-cannot-find-member[snippets='http-request,request-body,request-fields,response-body']
+== 로그인 실패 (잘못된 비밀번호)
+operation::fail-login-wrong-password[snippets='http-request,request-body,request-fields,response-body']
 
 [[find-id]]
-== 아이디 찾기
+== 아이디 찾기 성공
 operation::find-id-success[snippets='http-request,request-body,request-fields,response-body,response-fields']
+== 아이디 찾기 실패
+operation::fail-find-id[snippets='http-request,request-body,request-fields,response-body']
 
 [[Change-Pwd]]
 == 비밀번호 변경
 operation::change_pwd_success[snippets='http-request,path-parameters,request-body,request-fields,response-body']
+== 비밀번호 변경 실패 (해당 정보 가진 유저 X)
+operation::fail_change_pwd_not_found_member[snippets='http-request,request-body,request-fields,response-body']
+== 비밀번호 변경 실패 (비밀번호 1, 2 같지 않음)
+operation::fail_change_pwd_not_same_password[snippets='http-request,request-body,request-fields,response-body']
+== 비밀번호 변경 실패 (이전 비밀번호와 동일)
+operation::fail_change_pwd_cannot_use_same_password[snippets='http-request,request-body,request-fields,response-body']
 
 [[Check-LoginId]]
-== 아이디 중복 확인 (아이디 X)
+== 아이디 중복 확인 (아이디 생성 가능)
 operation::success-check-loginId[snippets='http-request,request-body,request-fields,response-body']
-== 아이디 중복 확인 (아이디 O)
-operation::error-find-loginId[snippets='http-request,request-body,request-fields,response-body,response-fields']
+== 아이디 중복 확인 (아이디 이미 존재)
+operation::error-find-loginId[snippets='http-request,request-body,request-fields,response-body']
 
 [[Enter]]
 == 입점 신청
 === Bearer 토큰 사용하여 로그인 여부 확인 (아래 토큰(Authorization)은 직접 로그인 후 발급받아 사용하여야 함)
 operation::success-save-enter[snippets='http-request,request-body,request-fields,response-body,response-fields']
-== 입점 신청 실패
-operation::fail-save-enter[snippets='http-request,request-body,request-fields,response-body,response-fields']
+== 입점 신청 실패 (1번 이상 신청)
+operation::fail-save-enter-apply-twice[snippets='http-request,request-body,request-fields,response-body']
+== 입점 신청 실패 (사장님 찾을 수 없음)
+operation::fail-save-enter-cannot-find-member[snippets='http-request,request-body,request-fields,response-body']
 
 [[회원탈퇴]]
-== 회원 탈퇴 요청
+== 회원 탈퇴 요청 성공
 operation::success-wantDelete[snippets='http-request,path-parameters,response-body']
-
-== 회원 탈퇴 요청 (사장님 id 없을 때)
+== 회원 탈퇴 요청 실패 (사장님 id 없을 때)
 operation::fail-wantDelete-seller-err[snippets='http-request,path-parameters,response-body']
+== 회원 탈퇴 요청 실패 (가게 id 없을 때)
+operation::fail-wantDelete-store-err[snippets='http-request,path-parameters,response-body']

--- a/member/src/main/java/com/zupzup/untact/api/impl/EnterControllerImpl.java
+++ b/member/src/main/java/com/zupzup/untact/api/impl/EnterControllerImpl.java
@@ -2,11 +2,15 @@ package com.zupzup.untact.api.impl;
 
 import com.zupzup.untact.api.BaseControllerImpl;
 import com.zupzup.untact.api.EnterController;
+import com.zupzup.untact.exception.member.MemberException;
+import com.zupzup.untact.exception.store.StoreException;
 import com.zupzup.untact.model.Enter;
 import com.zupzup.untact.model.request.EnterReq;
 import com.zupzup.untact.model.response.EnterRes;
 import com.zupzup.untact.repository.EnterRepository;
 import com.zupzup.untact.service.BaseService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,5 +20,19 @@ public class EnterControllerImpl extends BaseControllerImpl<Enter, EnterReq, Ent
 
     public EnterControllerImpl(BaseService<Enter, EnterReq, EnterRes, EnterRepository> baseService) {
         super(baseService);
+    }
+
+    @ExceptionHandler(StoreException.class)
+    public ResponseEntity<String> handleStoreException(StoreException storeException) {
+
+        return new ResponseEntity<>(storeException.getExceptionType().getErrMsg(),
+                storeException.getExceptionType().getHttpStatus());
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<String> handleMemberException(MemberException memberException) {
+
+        return new ResponseEntity<>(memberException.getExceptionType().getErrMsg(),
+                memberException.getExceptionType().getHttpStatus());
     }
 }

--- a/member/src/main/java/com/zupzup/untact/exception/member/MemberExceptionType.java
+++ b/member/src/main/java/com/zupzup/untact/exception/member/MemberExceptionType.java
@@ -6,8 +6,9 @@ import org.springframework.http.HttpStatus;
 public enum MemberExceptionType implements BaseExceptionType {
     // 회원가입, 로그인 시
     ALREADY_EXIST_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
+    ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "이미 신청한 내역이 있는 회원입니다. (동일 이름 및 전화번호 존재)"),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 잘못되었습니다."),
-    NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "회원 정보가 없습니다."),
+    NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "회원을 찾을 수 없습니다."),
     NOT_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 같지 않습니다."),
     CANNOT_USE_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "이전 비밀번호와 같은 비밀번호를 사용할 수 없습니다."),
     ALREADY_WANTED_DELETE(HttpStatus.BAD_REQUEST,"이미 탈퇴를 신청한 회원입니다."),

--- a/member/src/main/java/com/zupzup/untact/model/Member.java
+++ b/member/src/main/java/com/zupzup/untact/model/Member.java
@@ -25,6 +25,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false) private String email; // 이메일 주소
     @Column(nullable = false) private Boolean ad; // 광고성 정보 수신 동의 여부
     @Column private int cnt; // 지원 횟수
+    // @Column private int numOfApplicant; // 지원 횟수
 
     @Column private Long sellerId; // seller 저장 후 sellerId 저장
 //    @Column(nullable = false)

--- a/member/src/main/java/com/zupzup/untact/service/auth/SignService.java
+++ b/member/src/main/java/com/zupzup/untact/service/auth/SignService.java
@@ -61,7 +61,7 @@ public class SignService {
         // 비밀번호 동일 여부 확인
         if (!rq.getLoginPwd1().equals(rq.getLoginPwd2())) {
 
-            // 같지 않으면 rs 전송
+            // 같지 않으면 exception 발생
             throw new MemberException(NOT_SAME_PASSWORD);
         }
 

--- a/member/src/main/java/com/zupzup/untact/service/impl/MemberServiceImpl.java
+++ b/member/src/main/java/com/zupzup/untact/service/impl/MemberServiceImpl.java
@@ -21,7 +21,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
-import static com.zupzup.untact.exception.member.MemberExceptionType.ALREADY_EXIST_USERNAME;
+import static com.zupzup.untact.exception.member.MemberExceptionType.*;
 
 @Service
 public class MemberServiceImpl extends BaseServiceImpl<Member, MemberReq, MemberRes, MemberRepository> implements MemberService {
@@ -63,21 +63,13 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberReq, Member
         // 이름과 전화번호가 같은 사람이 있는지 확인
         if (memberRepository.existsByNameAndPhoneNum(rq.getName(), rq.getPhoneNum())) {
 
-            // 존재하면 rs 전송
-            MemberRes rs = new MemberRes();
-            rs.setLoginId("이미 존재하는 회원입니다.");
-
-            return rs;
+            throw new MemberException(ALREADY_EXIST_MEMBER);
         }
 
         // 비밀번호 동일 여부 확인
         if (!rq.getLoginPwd1().equals(rq.getLoginPwd2())) {
 
-            // 같지 않으면 rs 전송
-            MemberRes rs = new MemberRes();
-            rs.setLoginId("비밀번호가 같지 않습니다.");
-
-            return rs;
+            throw new MemberException(NOT_SAME_PASSWORD);
         }
 
         // 패스워드 인코딩 후 저장

--- a/member/src/test/java/com/zupzup/untact/api/CancelApiTest.java
+++ b/member/src/test/java/com/zupzup/untact/api/CancelApiTest.java
@@ -2,8 +2,7 @@
 //
 //import com.fasterxml.jackson.databind.ObjectMapper;
 //import com.zupzup.untact.documents.RestDocsConfig;
-//import com.zupzup.untact.exception.apple.AppleException;
-//import com.zupzup.untact.exception.apple.AppleExceptionType;
+//import com.zupzup.untact.exception.member.MemberException;
 //import com.zupzup.untact.exception.store.StoreException;
 //import com.zupzup.untact.service.impl.CancelServiceImpl;
 //import org.junit.jupiter.api.BeforeEach;
@@ -22,14 +21,15 @@
 //import org.springframework.web.context.WebApplicationContext;
 //import org.springframework.web.filter.CharacterEncodingFilter;
 //
-//import static com.zupzup.untact.exception.apple.AppleExceptionType.NO_MEMBER;
+//import static com.zupzup.untact.exception.member.MemberExceptionType.NOT_FOUND_MEMBER;
+//import static com.zupzup.untact.exception.store.StoreExceptionType.NO_MATCH_STORE;
 //import static org.mockito.Mockito.when;
 //import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 //import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 //import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 //import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 //import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 //import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 //import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 //
@@ -91,7 +91,7 @@
 //    @DisplayName("회원탈퇴 요청 - 회원 찾기 실패")
 //    public void fail_wantDelete() throws Exception {
 //
-//        when(cancelService.wantDelete(1L)).thenThrow(new AppleException(NO_MEMBER));
+//        when(cancelService.wantDelete(1L)).thenThrow(new MemberException(NOT_FOUND_MEMBER));
 //
 //        // when
 //        mockMvc.perform(
@@ -100,6 +100,26 @@
 //                // then
 //                .andExpect(status().isBadRequest())
 //                .andDo(document("fail-wantDelete-seller-err",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("id").description("seller unique id")
+//                        )));
+//    }
+//
+//    @Test
+//    @DisplayName("회원탈퇴 요청 - 가게 찾기 실패")
+//    public void fail_wantDelete_cannotFindStore() throws Exception {
+//
+//        when(cancelService.wantDelete(1L)).thenThrow(new StoreException(NO_MATCH_STORE));
+//
+//        // when
+//        mockMvc.perform(
+//                        patch("/cancel/{id}", 1L)
+//                                .header("Authorization", "Bearer " + bearerToken))
+//                // then
+//                .andExpect(status().isBadRequest())
+//                .andDo(document("fail-wantDelete-store-err",
 //                        preprocessRequest(prettyPrint()),
 //                        preprocessResponse(prettyPrint()),
 //                        pathParameters(

--- a/member/src/test/java/com/zupzup/untact/api/EnterApiTest.java
+++ b/member/src/test/java/com/zupzup/untact/api/EnterApiTest.java
@@ -2,7 +2,8 @@
 //
 //import com.fasterxml.jackson.databind.ObjectMapper;
 //import com.zupzup.untact.documents.RestDocsConfig;
-//import com.zupzup.untact.model.Member;
+//import com.zupzup.untact.exception.member.MemberException;
+//import com.zupzup.untact.exception.store.StoreException;
 //import com.zupzup.untact.model.request.EnterReq;
 //import com.zupzup.untact.model.response.EnterRes;
 //import com.zupzup.untact.service.impl.EnterServiceImpl;
@@ -25,10 +26,11 @@
 //import org.springframework.web.context.WebApplicationContext;
 //import org.springframework.web.filter.CharacterEncodingFilter;
 //
-//import java.util.Optional;
-//
+//import static com.zupzup.untact.exception.member.MemberExceptionType.NOT_FOUND_MEMBER;
+//import static com.zupzup.untact.exception.store.StoreExceptionType.CANNOT_APPLY_TWICE;
 //import static org.mockito.ArgumentMatchers.any;
 //import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.when;
 //import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 //import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 //import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -138,27 +140,25 @@
 //        rq.setPhoneNum("010-1111-1111");
 //        rq.setStoreName("test storeName");
 //        rq.setStoreAddress("test address");
-//        rq.setCrNumber("test cr Num");
+//        rq.setLongitude(12.345);
+//        rq.setLatitude(67.890);
+//        rq.setCrNumber("test 사업자번호");
 //
-//        String jsonRq = objectMapper.writeValueAsString(rq);
+//        String enterRq = objectMapper.writeValueAsString(rq);
 //
-//        EnterRes rs = new EnterRes();
-//        rs.setStoreName("입점 신청은 한 번만 가능합니다.");
-//
-//        given(enterService.save(any(EnterReq.class))).willReturn(rs); // 서비스에서 예외 발생 모방
+//        when(enterService.save(any(EnterReq.class))).thenThrow(new StoreException(CANNOT_APPLY_TWICE));
 //
 //        // when & then
 //        mockMvc.perform(
 //                        post("/enter")
 //                                .header("Authorization", "Bearer " + bearerToken)
 //                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(jsonRq)
+//                                .content(enterRq)
 //                )
-//                .andExpect(status().isCreated())
-//                .andExpect(jsonPath("storeName").value("입점 신청은 한 번만 가능합니다."))
+//                .andExpect(status().isBadRequest())
 //                .andDo(
 //                        document(
-//                                "fail-save-enter",
+//                                "fail-save-enter-apply-twice",
 //                                preprocessRequest(prettyPrint()),
 //                                preprocessResponse(prettyPrint()),
 //                                requestFields(
@@ -167,11 +167,55 @@
 //                                        fieldWithPath("phoneNum").type(JsonFieldType.STRING).description("사장님 전화번호"),
 //                                        fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
 //                                        fieldWithPath("storeAddress").type(JsonFieldType.STRING).description("가게 주소"),
+//                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
+//                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
 //                                        fieldWithPath("crNumber").type(JsonFieldType.STRING).description("사업자 등록 번호")
-//                                ),
-//                                responseFields(
-//                                        fieldWithPath("id").type(JsonFieldType.NULL).description(""),
-//                                        fieldWithPath("storeName").type(JsonFieldType.STRING).description("실패 이유")
+//                                )
+//                        )
+//                );
+//    }
+//
+//    @Test
+//    @DisplayName("입점 신청 - 실패 (사장님 id 찾지 못함)")
+//    public void fail_cannot_find_member() throws Exception {
+//
+//        // given
+//        EnterReq rq = new EnterReq();
+//        rq.setId(1L);
+//        rq.setName("사장님 이름");
+//        rq.setPhoneNum("010-1111-1111");
+//        rq.setStoreName("test storeName");
+//        rq.setStoreAddress("test address");
+//        rq.setLongitude(12.345);
+//        rq.setLatitude(67.890);
+//        rq.setCrNumber("test 사업자번호");
+//
+//        String enterRq = objectMapper.writeValueAsString(rq);
+//
+//        when(enterService.save(any(EnterReq.class))).thenThrow(new MemberException(NOT_FOUND_MEMBER));
+//
+//        // when & then
+//        mockMvc.perform(
+//                        post("/enter")
+//                                .header("Authorization", "Bearer " + bearerToken)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(enterRq)
+//                )
+//                .andExpect(status().isBadRequest())
+//                .andDo(
+//                        document(
+//                                "fail-save-enter-cannot-find-member",
+//                                preprocessRequest(prettyPrint()),
+//                                preprocessResponse(prettyPrint()),
+//                                requestFields(
+//                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("사장님 unique Id"),
+//                                        fieldWithPath("name").type(JsonFieldType.STRING).description("사장님 이름"),
+//                                        fieldWithPath("phoneNum").type(JsonFieldType.STRING).description("사장님 전화번호"),
+//                                        fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+//                                        fieldWithPath("storeAddress").type(JsonFieldType.STRING).description("가게 주소"),
+//                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
+//                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+//                                        fieldWithPath("crNumber").type(JsonFieldType.STRING).description("사업자 등록 번호")
 //                                )
 //                        )
 //                );

--- a/member/src/test/java/com/zupzup/untact/api/MemberApiTest.java
+++ b/member/src/test/java/com/zupzup/untact/api/MemberApiTest.java
@@ -26,7 +26,7 @@
 //import org.springframework.web.context.WebApplicationContext;
 //import org.springframework.web.filter.CharacterEncodingFilter;
 //
-//import static com.zupzup.untact.exception.member.MemberExceptionType.ALREADY_EXIST_USERNAME;
+//import static com.zupzup.untact.exception.member.MemberExceptionType.*;
 //import static org.mockito.ArgumentMatchers.any;
 //import static org.mockito.BDDMockito.given;
 //import static org.mockito.Mockito.when;
@@ -59,28 +59,6 @@
 //                .addFilters(new CharacterEncodingFilter("UTF-8", true))
 //                .alwaysDo(print())
 //                .build();
-//    }
-//
-//    /**
-//     * 테스트시 쓰기 위한 에러 Response
-//     */
-//    static class TestExceptionRes {
-//
-//        private Integer errCode;
-//        private String errMsg;
-//
-//        public TestExceptionRes(Integer errCode, String errMsg) {
-//            this.errCode = errCode;
-//            this.errMsg = errMsg;
-//        }
-//
-//        public Integer getErrCode() {
-//            return errCode;
-//        }
-//
-//        public String getErrMsg() {
-//            return errMsg;
-//        }
 //    }
 //
 //    @Test
@@ -145,6 +123,91 @@
 //                ));
 //    }
 //
+//    @Test
+//    @DisplayName("사장님 생성/회원가입 - 실패 - 이미 존재하는 회원")
+//    public void fail_save_already_exists() throws Exception {
+//
+//        // given
+//        when(memberService.save(any(MemberReq.class))).thenThrow(new MemberException(ALREADY_EXIST_MEMBER));
+//
+//        // when
+//        mockMvc.perform(
+//                        // POST 요청
+//                        post(url)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .accept(MediaType.APPLICATION_JSON)
+//                                .content(
+//                                        "{"
+//                                                + " \"name\": \"test\", "
+//                                                + " \"phoneNum\": \"010-1111-1111\", "
+//                                                + " \"ad\": false, "
+//                                                + " \"loginId\": \"test\", "
+//                                                + " \"loginPwd1\": \"pwd1\", "
+//                                                + " \"loginPwd2\": \"pwd1\", "
+//                                                + " \"email\": \"email\" "
+//                                                + "}"
+//                                )
+//                )
+//                // then
+//                .andExpect(status().isBadRequest())
+//                .andDo(document(
+//                        "fail-create-seller-already-exists",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        requestFields(
+//                                fieldWithPath("name").type(JsonFieldType.STRING).description("사장님 이름"),
+//                                fieldWithPath("phoneNum").type(JsonFieldType.STRING).description("사장님 전화번호"),
+//                                fieldWithPath("ad").type(JsonFieldType.BOOLEAN).description("광고성 정보 수신 동의 여부"),
+//                                fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 아이디"),
+//                                fieldWithPath("loginPwd1").type(JsonFieldType.STRING).description("로그인 비밀번호"),
+//                                fieldWithPath("loginPwd2").type(JsonFieldType.STRING).description("로그인 비밀번호(같은지 서버에서 한 번 더 확인)"),
+//                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+//                        )
+//                ));
+//    }
+//
+//    @Test
+//    @DisplayName("사장님 생성/회원가입 - 실패 - 비밀번호 동일 여부 확인")
+//    public void fail_save_not_same_password() throws Exception {
+//
+//        // given
+//        when(memberService.save(any(MemberReq.class))).thenThrow(new MemberException(NOT_SAME_PASSWORD));
+//
+//        // when
+//        mockMvc.perform(
+//                        // POST 요청
+//                        post(url)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .accept(MediaType.APPLICATION_JSON)
+//                                .content(
+//                                        "{"
+//                                                + " \"name\": \"test\", "
+//                                                + " \"phoneNum\": \"010-1111-1111\", "
+//                                                + " \"ad\": false, "
+//                                                + " \"loginId\": \"test\", "
+//                                                + " \"loginPwd1\": \"pwd1\", "
+//                                                + " \"loginPwd2\": \"pwd12\", "
+//                                                + " \"email\": \"email\" "
+//                                                + "}"
+//                                )
+//                )
+//                // then
+//                .andExpect(status().isBadRequest())
+//                .andDo(document(
+//                        "fail-create-seller-not-same-password",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        requestFields(
+//                                fieldWithPath("name").type(JsonFieldType.STRING).description("사장님 이름"),
+//                                fieldWithPath("phoneNum").type(JsonFieldType.STRING).description("사장님 전화번호"),
+//                                fieldWithPath("ad").type(JsonFieldType.BOOLEAN).description("광고성 정보 수신 동의 여부"),
+//                                fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 아이디"),
+//                                fieldWithPath("loginPwd1").type(JsonFieldType.STRING).description("로그인 비밀번호"),
+//                                fieldWithPath("loginPwd2").type(JsonFieldType.STRING).description("로그인 비밀번호(같은지 서버에서 한 번 더 확인)"),
+//                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+//                        )
+//                ));
+//    }
 //
 //    @Test
 //    @DisplayName("중복 아이디 확인 - 아이디 존재")
@@ -183,32 +246,27 @@
 //    }
 //
 //    @Test
-//    @DisplayName("중복 아이디 확인 - 아이디 없음")
+//    @DisplayName("중복 아이디 확인 - 아이디 이미 존재")
 //    public void fail_find_loginId() throws Exception {
 //
 //        // given
-//        MemberLoginIdReq rq = new MemberLoginIdReq();
-//        rq.setLoginId("test");
-//
-//        TestExceptionRes rs = new TestExceptionRes(600, "이미 존재하는 아이디입니다.");
-//
-//        // 값 json 으로 매핑
 //        ObjectMapper objectMapper = new ObjectMapper();
-//        String jsonRq = objectMapper.writeValueAsString(rq);
-//        String jsonEx = objectMapper.writeValueAsString(rs);
+//
+//        MemberLoginIdReq loginIdReq = new MemberLoginIdReq();
+//        loginIdReq.setLoginId("Test Login ID");
 //
 //        when(memberService.checkLoginId(any(String.class))).thenThrow(new MemberException(ALREADY_EXIST_USERNAME));
+//
+//        String loginId = objectMapper.writeValueAsString(loginIdReq);
 //
 //        // when
 //        mockMvc.perform(
 //                post(url + "/check")
 //                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(jsonRq)
+//                        .content(loginId)
 //        )
 //        // then
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("errCode").value(600))
-//                .andExpect(jsonPath("errMsg").value("이미 존재하는 아이디입니다."))
+//                .andExpect(status().isBadRequest())
 //                .andDo(
 //                        document(
 //                                "error-find-loginId",
@@ -216,10 +274,6 @@
 //                                preprocessResponse(prettyPrint()),
 //                                requestFields(
 //                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("중복 확인을 위한 로그인 아이디(String)")
-//                                ),
-//                                responseFields(
-//                                        fieldWithPath("errCode").description("에러 코드"),
-//                                        fieldWithPath("errMsg").description("에러 메세지")
 //                                )
 //                        )
 //                );


### PR DESCRIPTION
## 🔍 개요
- #89

## 📝 작업사항
### 1. Exception 수정
- BaseService, BaseController에서 try-catch 문 제거
  - 커스텀한 Exception을 사용하기 위해 base service, base controller 에서 Exception 제거
- MemberExceptionType, StoreExceptionType 수정
  - 내용의 통일성을 위해 Exception 내용 수정
  - 필요한 내용 추가
  - AppleException 제거
- Service에 Exception 추가
  -  기존 ResponseEntity를 사용하여 에러 값을 전달하던 것을 ExceptionHandler를 사용하여 처리
  - try-catch 문 제거

### 2. 문서화
- 관련 내용 문서화

## 🧐 참고 사항
- 이후 exception 네이밍 수정 필요