### PR TITLE
Refactor : ResultService 전체 리스트 보여주는 함수 추가

### DIFF
--- a/manager/src/main/java/com/zupzup/untact/service/impl/ResultServiceImpl.java
+++ b/manager/src/main/java/com/zupzup/untact/service/impl/ResultServiceImpl.java
@@ -27,6 +27,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.zupzup.untact.exception.ManagerExceptionType.EMPTY_LIST;
 import static com.zupzup.untact.exception.enter.EnterExceptionType.*;
@@ -44,6 +45,18 @@ public class ResultServiceImpl implements ResultService {
     private final StoreRepository storeRepository;
     private final SellerRepository sellerRepository;
 
+    // generic
+
+    /**
+     * S를 T로 변환하여 전달
+     */
+    private <S, T> List<T> convertEntityListToDtoList(List<S> sourceList, Class<T> targetClass) {
+
+        return sourceList.stream()
+                .map(entity -> modelMapper.map(entity, targetClass))
+                .collect(Collectors.toList());
+    }
+
     // --------- NEW ---------
 
     /**
@@ -52,21 +65,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<EnterListRes> enterList() {
 
-        List<Enter> eList = enterRepository.findByState(EnterState.NEW);
+        List<Enter> enterList = enterRepository.findByState(EnterState.NEW);;
 
-        // list 길이가 0일 빈 리스트값 전달
-        if (eList.size() == 0) {
-            return new ArrayList<>();
-        }
-
-        List<EnterListRes> eListRes = new ArrayList<>();
-
-        for (Enter e : eList) {
-
-            eListRes.add(modelMapper.map(e, EnterListRes.class));
-        }
-
-        return eListRes;
+        return convertEntityListToDtoList(enterList, EnterListRes.class);
     }
 
     /**
@@ -206,21 +207,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<WaitStoreListRes> waitStoreList() {
 
-        List<Store> sList = storeRepository.findByEnterState(EnterState.WAIT);
+        List<Store> WaitStoreList = storeRepository.findByEnterState(EnterState.WAIT);
 
-        // list 사이즈가 0일 경우 빈 배열 리턴
-        if (sList.size() == 0) {
-            return new ArrayList<>();
-        }
-
-        List<WaitStoreListRes> wsList = new ArrayList<>();
-
-        for (Store s : sList) {
-
-            wsList.add(modelMapper.map(s, WaitStoreListRes.class));
-        }
-
-        return wsList;
+        return convertEntityListToDtoList(WaitStoreList, WaitStoreListRes.class);
     }
 
     /**
@@ -346,21 +335,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<ConfirmStoreListRes> confirmStoreList() {
 
-        List<Store> sList = storeRepository.findByEnterState(EnterState.CONFIRM);
+        List<Store> confirmStoreList = storeRepository.findByEnterState(EnterState.CONFIRM);
 
-        // list 사이즈가 0일 경우 빈 배열 리턴
-        if (sList.size() == 0) {
-            return new ArrayList<>();
-        }
-
-        List<ConfirmStoreListRes> csList = new ArrayList<>();
-
-        for (Store s : sList) {
-
-            csList.add(modelMapper.map(s, ConfirmStoreListRes.class));
-        }
-
-        return csList;
+        return convertEntityListToDtoList(confirmStoreList, ConfirmStoreListRes.class);
     }
 
     /**

--- a/manager/src/main/java/com/zupzup/untact/service/impl/ResultServiceImpl.java
+++ b/manager/src/main/java/com/zupzup/untact/service/impl/ResultServiceImpl.java
@@ -50,7 +50,7 @@ public class ResultServiceImpl implements ResultService {
     /**
      * S를 T로 변환하여 전달
      */
-    private <S, T> List<T> convertEntityListToDtoList(List<S> sourceList, Class<T> targetClass) {
+    private <S, T> List<T> entireList(List<S> sourceList, Class<T> targetClass) {
 
         return sourceList.stream()
                 .map(entity -> modelMapper.map(entity, targetClass))
@@ -67,7 +67,7 @@ public class ResultServiceImpl implements ResultService {
 
         List<Enter> enterList = enterRepository.findByState(EnterState.NEW);;
 
-        return convertEntityListToDtoList(enterList, EnterListRes.class);
+        return entireList(enterList, EnterListRes.class);
     }
 
     /**
@@ -182,21 +182,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<EnterListRes> searchEnterList(String keyword) {
 
-        List<Enter> eList = enterRepository.searchByStoreNameContainingAndState(keyword, EnterState.NEW);
+        List<Enter> enterList = enterRepository.searchByStoreNameContainingAndState(keyword, EnterState.NEW);
 
-        // 비어 있을 경우 빈 리스트 전달
-        if (eList.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        List<EnterListRes> eListRes = new ArrayList<>();
-
-        for (Enter e : eList) {
-
-            eListRes.add(modelMapper.map(e, EnterListRes.class));
-        }
-
-        return eListRes;
+        return entireList(enterList, EnterListRes.class);
     }
 
     // --------- WAIT ---------
@@ -209,7 +197,7 @@ public class ResultServiceImpl implements ResultService {
 
         List<Store> WaitStoreList = storeRepository.findByEnterState(EnterState.WAIT);
 
-        return convertEntityListToDtoList(WaitStoreList, WaitStoreListRes.class);
+        return entireList(WaitStoreList, WaitStoreListRes.class);
     }
 
     /**
@@ -309,22 +297,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<WaitStoreListRes> searchWaitStoreList(String keyword) {
 
-        List<Store> sList = storeRepository.searchByStoreNameContainingAndEnterState(keyword, EnterState.WAIT);
+        List<Store> waitStoreList = storeRepository.searchByStoreNameContainingAndEnterState(keyword, EnterState.WAIT);
 
-        // 리스트가 비어있을 경우
-        if (sList.isEmpty()) {
-
-            return new ArrayList<>();
-        }
-
-        List<WaitStoreListRes> wsList = new ArrayList<>();
-
-        for (Store s : sList) {
-
-            wsList.add(modelMapper.map(s, WaitStoreListRes.class));
-        }
-
-        return wsList;
+        return entireList(waitStoreList, WaitStoreListRes.class);
     }
 
     // --------- CONFIRM ---------
@@ -337,7 +312,7 @@ public class ResultServiceImpl implements ResultService {
 
         List<Store> confirmStoreList = storeRepository.findByEnterState(EnterState.CONFIRM);
 
-        return convertEntityListToDtoList(confirmStoreList, ConfirmStoreListRes.class);
+        return entireList(confirmStoreList, ConfirmStoreListRes.class);
     }
 
     /**
@@ -401,22 +376,9 @@ public class ResultServiceImpl implements ResultService {
     @Override
     public List<ConfirmStoreListRes> searchConfirmStoreList(String keyword) {
 
-        List<Store> sList = storeRepository.searchByStoreNameContainingAndEnterState(keyword, EnterState.CONFIRM);
+        List<Store> confirmStoreList = storeRepository.searchByStoreNameContainingAndEnterState(keyword, EnterState.CONFIRM);
 
-        // 리스트가 비어있을 경우
-        if (sList.isEmpty()) {
-
-            return new ArrayList<>();
-        }
-
-        List<ConfirmStoreListRes> csList = new ArrayList<>();
-
-        for (Store s : sList) {
-
-            csList.add(modelMapper.map(s, ConfirmStoreListRes.class));
-        }
-
-        return csList;
+        return entireList(confirmStoreList, ConfirmStoreListRes.class);
     }
 
     //-----------------------------

--- a/manager/src/test/java/com/zupzup/untact/api/ResultApiTest.java
+++ b/manager/src/test/java/com/zupzup/untact/api/ResultApiTest.java
@@ -616,13 +616,11 @@
 //    }
 //
 //    @Test
-//    @DisplayName("노출 대기 매장 전체 보기 - 실패")
-//    public void fail_wait_list() throws Exception {
+//    @DisplayName("노출 대기 매장 전체 보기 - 데이터 없음")
+//    public void no_data_wait_list() throws Exception {
 //
 //        // given
-//        TestExceptionRes rs = new TestExceptionRes(802, "관련된 매장 정보를 찾을 수 없습니다.");
-//
-//        when(resultService.waitStoreList()).thenThrow(new ManagerException(EMPTY_LIST));
+//        when(resultService.waitStoreList()).thenReturn(new ArrayList<>());
 //
 //        // when
 //        mockMvc.perform(
@@ -631,17 +629,15 @@
 //                )
 //                // then
 //                .andExpect(status().isOk())
-//                .andExpect(jsonPath("errCode").value(802))
-//                .andExpect(jsonPath("errMsg").value("관련된 매장 정보를 찾을 수 없습니다."))
+//                .andExpect(content().string("[]"))
 //                .andDo(document(
-//                        "fail-wait-list",
+//                        "none-data-wait-list",
 //                        preprocessRequest(prettyPrint()),
 //                        preprocessResponse(prettyPrint()),
 //                        responseFields(
-//                                fieldWithPath("errCode").description("에러 코드"),
-//                                fieldWithPath("errMsg").description("에러 메세지")
-//                        )
-//                ));
+//                                fieldWithPath("[]").description("빈 리스트 전달")
+//                        ))
+//                );
 //    }
 //
 //    @Test
@@ -1100,6 +1096,31 @@
 //                                fieldWithPath("[].sellerName").type(JsonFieldType.STRING).description("판매자 이름"),
 //                                fieldWithPath("[].storeName").type(JsonFieldType.STRING).description("가게 이름"),
 //                                fieldWithPath("[].confirmStatusTimestamp").type(JsonFieldType.STRING).description("변경된 시간")
+//                        ))
+//                );
+//    }
+//
+//    @Test
+//    @DisplayName("노출 승인 매장 전체보기 - 데이터 없음")
+//    public void none_data_confirm_list() throws Exception {
+//
+//        // given
+//        when(resultService.confirmStoreList()).thenReturn(new ArrayList<>());
+//
+//        // when
+//        mockMvc.perform(
+//                        get("/confirm")
+//                                .header("Authorization", "Bearer " + bearerToken)
+//                )
+//                // then
+//                .andExpect(status().isOk())
+//                .andExpect(content().string("[]"))
+//                .andDo(document(
+//                        "none-data-confirm-list",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        responseFields(
+//                                fieldWithPath("[]").description("빈 리스트 전달")
 //                        ))
 //                );
 //    }

--- a/member/src/main/java/com/zupzup/untact/service/impl/MemberServiceImpl.java
+++ b/member/src/main/java/com/zupzup/untact/service/impl/MemberServiceImpl.java
@@ -81,7 +81,7 @@ public class MemberServiceImpl extends BaseServiceImpl<Member, MemberReq, Member
                 .loginId(rq.getLoginId())
                 .loginPwd(passwordEncoder.encode(rq.getLoginPwd1()))
                 .email(rq.getEmail())
-                .cnt(0)
+                .applicationCnt(0)
                 .build();
 
         member.setRoles(


### PR DESCRIPTION
## 🔍 개요
- #95 

## 📝 작업사항
- arrayList 생성 코드 > entireList() 함수
  - 기존 배열을 새로 생성해서 관련 리스트를 전송하는 방식에서 제네릭을 이용한 `entireList` 함수를 통한 배열 생성 및 전달로 수정
  - 사용 위치 : 전체 리스트, 검색 리스트

